### PR TITLE
feat: improve pin management

### DIFF
--- a/internal/pritunl/user.go
+++ b/internal/pritunl/user.go
@@ -66,7 +66,7 @@ func (pin Pin) MarshalJSON() ([]byte, error) {
 	return json.Marshal(pin.IsSet)
 }
 
-func (pin Pin) UnmarshalJSON(data []byte) error {
+func (pin *Pin) UnmarshalJSON(data []byte) error {
 	var i interface{}
 	err := json.Unmarshal(data, &i)
 	if err != nil {
@@ -75,7 +75,11 @@ func (pin Pin) UnmarshalJSON(data []byte) error {
 	switch v := i.(type) {
 	case bool:
 		pin.IsSet = v
-		pin.Value = ""
+		if pin.IsSet {
+			pin.Value = "unknown"
+		} else {
+			pin.Value = ""
+		}
 	case string:
 		pin.IsSet = true
 		pin.Value = v

--- a/internal/pritunl/user_test.go
+++ b/internal/pritunl/user_test.go
@@ -1,6 +1,7 @@
 package pritunl_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/atobaum/terraform-provider-pritunl/internal/pritunl"
@@ -12,15 +13,22 @@ func TestPinMarshal(t *testing.T) {
 
 	res, err := p.MarshalJSON()
 
-	assert.Equal(t, err, nil)
-	assert.Equal(t, string(res), "true")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "true", string(res))
 
 	p = pritunl.Pin{IsSet: true, Value: "pin_ex"}
 
 	res, err = p.MarshalJSON()
 
-	assert.Equal(t, err, nil)
-	assert.Equal(t, string(res), "\"pin_ex\"")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "\"pin_ex\"", string(res))
+
+	p = pritunl.Pin{IsSet: true, Value: "unknown"}
+
+	res, err = p.MarshalJSON()
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "true", string(res))
 
 	p = pritunl.Pin{IsSet: false, Value: "pin_ex"}
 
@@ -32,6 +40,39 @@ func TestPinMarshal(t *testing.T) {
 
 	res, err = p.MarshalJSON()
 
-	assert.Equal(t, err, nil)
-	assert.Equal(t, string(res), "false")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "false", string(res))
+}
+
+func TestIntialValue(t *testing.T) {
+	p := pritunl.Pin{}
+
+	assert.Equal(t, false, p.IsSet)
+	assert.Equal(t, "", p.Value)
+}
+
+func TestPinUnmarshal(t *testing.T) {
+	p := pritunl.Pin{}
+
+	err := json.Unmarshal([]byte("\"123123\""), &p)
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, true, p.IsSet)
+	assert.Equal(t, "123123", p.Value)
+
+	p = pritunl.Pin{}
+
+	err = json.Unmarshal([]byte("true"), &p)
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, true, p.IsSet)
+	assert.Equal(t, "unknown", p.Value)
+
+	p = pritunl.Pin{}
+
+	err = json.Unmarshal([]byte("false"), &p)
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, false, p.IsSet)
+	assert.Equal(t, "", p.Value)
 }

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -104,6 +104,12 @@ func resourceUser() *schema.Resource {
 				Optional:    true,
 				Description: "PIN code, must be six digits if set. Cannot be retrieved back.",
 			},
+			"pin_required": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Protect unsetting PIN code",
+			},
 			"pin_set": {
 				Type:        schema.TypeBool,
 				Computed:    true,
@@ -266,6 +272,10 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		} else {
 			user.Pin = pritunl.Pin{IsSet: false}
 		}
+	}
+
+	if d.Get("pin_required").(bool) && (!user.Pin.IsSet || user.Pin.Value == "") {
+		return diag.Errorf("User Pin should be set")
 	}
 
 	err = apiClient.UpdateUser(d.Id(), user)

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -155,6 +155,12 @@ func resourceUserRead(_ context.Context, d *schema.ResourceData, meta interface{
 	d.Set("pin_set", user.Pin.IsSet)
 	d.Set("otp_secret", user.OtpSecret)
 
+	if !user.Pin.IsSet && user.Pin.Value == "" {
+		d.Set("pin", nil)
+	} else if d.Get("pin") == "" {
+		d.Set("pin", "unknown")
+	}
+
 	if len(user.Groups) > 0 {
 		groupsList := make([]string, 0)
 


### PR DESCRIPTION
- fix: fix unmarshaling user pin
- feat: Add password_required property to the user resource
  - Throw error is `passord_required` has set but the pin is not configured. 7cdc9ea
- feat: update resource if pin has changed while reading 10dc962
  - update pin to "unknown" when the pin has set
  - update pin to "" when the pin has unset
